### PR TITLE
Allow finding jar files when properly versioning resources

### DIFF
--- a/python/rpdk/java/codegen.py
+++ b/python/rpdk/java/codegen.py
@@ -294,9 +294,7 @@ class JavaLanguagePlugin(LanguagePlugin):
     @staticmethod
     def _find_jar(project):
         jar_glob = list(
-            (project.root / "target").glob(
-                "{}-*.jar".format(project.hypenated_name)
-            )
+            (project.root / "target").glob("{}-*.jar".format(project.hypenated_name))
         )
         if not jar_glob:
             LOG.debug("No Java ARchives match")

--- a/python/rpdk/java/codegen.py
+++ b/python/rpdk/java/codegen.py
@@ -295,7 +295,7 @@ class JavaLanguagePlugin(LanguagePlugin):
     def _find_jar(project):
         jar_glob = list(
             (project.root / "target").glob(
-                "{}-*-SNAPSHOT.jar".format(project.hypenated_name)
+                "{}-*.jar".format(project.hypenated_name)
             )
         )
         if not jar_glob:


### PR DESCRIPTION
*Description of changes:*

Remove the hardcoded `-SNAPSHOT` when trying to find the `jar` after having executed `mvn package`. 
This allows to version the produced resources with `semver` like https://github.com/DataDog/datadog-cloudformation-resources/blob/master/datadog-iam-user-handler/pom.xml#L11 for instance, and have the `cfn` tool find it automatically, so as not to get 

```
No JAR artifact was found.
Please run 'mvn package' or the equivalent command in your IDE to compile and package the code.
```




By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
